### PR TITLE
Display saved images on the homepage

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,7 @@
  *= require_tree .
  *= require_self
  */
+
+.image-thumbnail {
+  max-width: 400px;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
-  def home; end
+  def home
+    @images = Image.order(created_at: :desc).all
+  end
 end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,0 +1,2 @@
+class ImagesController < ApplicationController
+end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,2 +1,3 @@
 class ImagesController < ApplicationController
+  def new; end
 end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,5 +1,7 @@
 class ImagesController < ApplicationController
-  def new; end
+  def new
+    @image = Image.new
+  end
 
   def create
     @image = Image.new(image_params)

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,3 +1,21 @@
 class ImagesController < ApplicationController
   def new; end
+
+  def create
+    @image = Image.new(image_params)
+
+    if @image.save
+      redirect_to @image
+    else
+      render :new
+    end
+  end
+
+  def show; end
+
+  private
+
+  def image_params
+    params.require(:image).permit(:url)
+  end
 end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -11,7 +11,9 @@ class ImagesController < ApplicationController
     end
   end
 
-  def show; end
+  def show
+    @image = Image.find(params[:id])
+  end
 
   private
 

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,0 +1,2 @@
+class Image < ApplicationRecord
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,2 +1,16 @@
 class Image < ApplicationRecord
+  validate :must_have_valid_url
+
+  def must_have_valid_url
+    errors.add(:url, 'must be a link to an image') unless valid_url?(url)
+  end
+
+  private
+
+  def valid_url?(value)
+    return false if value.nil?
+
+    uri = URI.parse(value)
+    uri.is_a?(URI::HTTP) && !uri.host.nil?
+  end
 end

--- a/app/views/application/home.html.erb
+++ b/app/views/application/home.html.erb
@@ -1,1 +1,3 @@
 <h1>Hello world</h1>
+
+<%= link_to "Submit a new image", new_image_path %>

--- a/app/views/application/home.html.erb
+++ b/app/views/application/home.html.erb
@@ -1,3 +1,13 @@
 <h1>Hello world</h1>
 
 <%= link_to "Submit a new image", new_image_path %>
+
+<main>
+  <ul id="image-list">
+    <% @images.each do |image| %>
+      <li>
+        <%= image_tag image.url %>
+      </li>
+    <% end %>
+  </ul>
+</main>

--- a/app/views/application/home.html.erb
+++ b/app/views/application/home.html.erb
@@ -7,7 +7,7 @@
     <% @images.each do |image| %>
       <li>
         <a href="<%= image_path(image) %>">
-          <%= image_tag image.url %>
+          <%= image_tag image.url, class: 'image-thumbnail' %>
         </a>
       </li>
     <% end %>

--- a/app/views/application/home.html.erb
+++ b/app/views/application/home.html.erb
@@ -6,7 +6,9 @@
   <ul id="image-list">
     <% @images.each do |image| %>
       <li>
-        <%= image_tag image.url %>
+        <a href="<%= image_path(image) %>">
+          <%= image_tag image.url %>
+        </a>
       </li>
     <% end %>
   </ul>

--- a/app/views/images/new.html.erb
+++ b/app/views/images/new.html.erb
@@ -1,6 +1,19 @@
 <%= form_with scope: :image, url: images_path, local: true do |f| %>
   <h1>Submit an Image</h1>
 
+  <% if @image.errors.any? %>
+    <div id="error_explanation">
+      <h2>
+        <%= pluralize(@image.errors.count, 'issue') %> prevented your image from being saved:
+      </h2>
+      <ul>
+        <% @image.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
   <p>
     <%= f.label :url, 'Image URL' %><br>
     <%= f.text_field :url %>

--- a/app/views/images/new.html.erb
+++ b/app/views/images/new.html.erb
@@ -1,0 +1,10 @@
+<%= form_with scope: :image, url: images_path, local: true do |f| %>
+  <h1>Submit an Image</h1>
+
+  <p>
+    <%= f.label :url, 'Image URL' %><br>
+    <%= f.text_field :url %>
+  </p>
+
+  <%= f.submit %>
+<% end %>

--- a/app/views/images/show.html.erb
+++ b/app/views/images/show.html.erb
@@ -1,0 +1,3 @@
+<main>
+  <%= image_tag @image.url %>
+</main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root 'application#home'
+
+  resources :images
 end

--- a/db/migrate/20200624223651_create_images.rb
+++ b/db/migrate/20200624223651_create_images.rb
@@ -1,0 +1,9 @@
+class CreateImages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :images do |t|
+      t.string :url
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,6 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2020_06_24_223651) do
+
+  create_table "images", force: :cascade do |t|
+    t.string "url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
 end

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class ApplicationControllerTest < ActionDispatch::IntegrationTest
+  test 'has a link to the image submission form' do
+    get root_url
+    assert_response :success
+    assert_select "a[href='#{new_image_path}']"
+  end
+end

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -6,4 +6,18 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select 'a[href=?]', new_image_path
   end
+
+  test 'displays newer images first' do
+    Image.delete_all
+    first_image = Image.create!(url: 'http://example.com/foo.png')
+    second_image = Image.create!(url: 'http://example.com/bar.png')
+
+    get root_url
+
+    assert_select 'img[src=?]', first_image.url
+    assert_select 'img[src=?]', second_image.url
+
+    assert body.index(second_image.url) < body.index(first_image.url),
+           'The most recent image should appear first'
+  end
 end

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -14,8 +14,12 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
 
     get root_url
 
-    assert_select 'img[src=?]', first_image.url
-    assert_select 'img[src=?]', second_image.url
+    assert_select 'a[href=?]', image_path(first_image) do
+      assert_select 'img[src=?]', first_image.url
+    end
+    assert_select 'a[href=?]', image_path(second_image) do
+      assert_select 'img[src=?]', second_image.url
+    end
 
     assert body.index(second_image.url) < body.index(first_image.url),
            'The most recent image should appear first'

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -4,6 +4,6 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
   test 'has a link to the image submission form' do
     get root_url
     assert_response :success
-    assert_select "a[href='#{new_image_path}']"
+    assert_select 'a[href=?]', new_image_path
   end
 end

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ImagesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -1,7 +1,26 @@
 require 'test_helper'
 
 class ImagesControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'does not show errors when first rendering the page' do
+    get new_image_url
+    assert_response :ok
+    assert_select '#error_explanation', count: 0
+  end
+
+  test 'adds valid images' do
+    image_src = 'http://example.com/foo.png'
+    assert_difference 'Image.count', 1 do
+      post images_url, params: { image: { url: image_src } }
+    end
+    assert_redirected_to Image.order(:created_at).last
+    follow_redirect!
+    assert_select "img[src='#{image_src}']"
+  end
+
+  test 'does not add invalid images' do
+    assert_no_changes 'Image.count' do
+      post images_path, params: { image: { url: '' } }
+    end
+    assert_select '#error_explanation'
+  end
 end

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -14,7 +14,7 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
     end
     assert_redirected_to Image.order(:created_at).last
     follow_redirect!
-    assert_select "img[src='#{image_src}']"
+    assert_select 'img[src=?]', image_src
   end
 
   test 'does not add invalid images' do

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+class ImageTest < ActiveSupport::TestCase
+  def setup
+    @image = Image.new(url: 'http://example.com/foo.png')
+  end
+
+  test 'valid image' do
+    assert @image.valid?
+  end
+
+  test 'valid image with https link' do
+    @image.url = 'https://example.com/foo.png'
+    assert @image.valid?
+  end
+
+  test 'invalid when url is blank' do
+    @image.url = ''
+    refute @image.valid?
+    assert_not_nil @image.errors[:url]
+  end
+
+  test 'invalid when url is nil' do
+    @image.url = nil
+    refute @image.valid?
+    assert_not_nil @image.errors[:url]
+  end
+
+  test 'invalid when url is not a url' do
+    @image.url = '???'
+    refute @image.valid?
+    assert_not_nil @image.errors[:url]
+  end
+
+  test 'invalid when url protocol is not http or https' do
+    @image.url = 'ws://example.com/foo.png'
+    refute @image.valid?
+    assert_not_nil @image.errors[:url]
+  end
+end


### PR DESCRIPTION
Closes #4.

This PR makes the homepage display all saved images on the homepage in reverse chronological order.

Draft until #11 is merged, can rebase after.