### PR TITLE
Implement image tagging functionality

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Exclude:
     - 'db/schema.rb'
+    - 'db/migrate/*.acts_as_taggable_on_engine.rb'
     - 'log/**/*'
     - 'tmp/**/*'
     - 'vendor/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ gem 'jquery-rails'
 
 gem 'webpacker', '~> 4'
 
+gem 'acts-as-taggable-on', '~> 6.0'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    acts-as-taggable-on (6.5.0)
+      activerecord (>= 5.0, < 6.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
@@ -225,6 +227,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts-as-taggable-on (~> 6.0)
   byebug
   capybara
   jquery-rails

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,7 @@
  *= require_tree .
  *= require_self
  */
+
+.image-thumbnail {
+  max-width: 400px;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
-  def home; end
+  def home
+    @images = Image.order(created_at: :desc).all
+  end
 end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,0 +1,2 @@
+class ImagesController < ApplicationController
+end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -20,6 +20,6 @@ class ImagesController < ApplicationController
   private
 
   def image_params
-    params.require(:image).permit(:url)
+    params.require(:image).permit(:url, :tag_list)
   end
 end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,2 +1,3 @@
 class ImagesController < ApplicationController
+  def new; end
 end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,5 +1,7 @@
 class ImagesController < ApplicationController
-  def new; end
+  def new
+    @image = Image.new
+  end
 
   def create
     @image = Image.new(image_params)

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,3 +1,21 @@
 class ImagesController < ApplicationController
   def new; end
+
+  def create
+    @image = Image.new(image_params)
+
+    if @image.save
+      redirect_to @image
+    else
+      render :new
+    end
+  end
+
+  def show; end
+
+  private
+
+  def image_params
+    params.require(:image).permit(:url)
+  end
 end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -11,7 +11,9 @@ class ImagesController < ApplicationController
     end
   end
 
-  def show; end
+  def show
+    @image = Image.find(params[:id])
+  end
 
   private
 

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,0 +1,2 @@
+class Image < ApplicationRecord
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,4 +1,5 @@
 class Image < ApplicationRecord
+  acts_as_taggable_on :tags
   validate :must_have_valid_url
 
   def must_have_valid_url

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,2 +1,16 @@
 class Image < ApplicationRecord
+  validate :must_have_valid_url
+
+  def must_have_valid_url
+    errors.add(:url, 'must be a link to an image') unless valid_url?(url)
+  end
+
+  private
+
+  def valid_url?(value)
+    return false if value.nil?
+
+    uri = URI.parse(value)
+    uri.is_a?(URI::HTTP) && !uri.host.nil?
+  end
 end

--- a/app/views/application/home.html.erb
+++ b/app/views/application/home.html.erb
@@ -1,1 +1,3 @@
 <h1>Hello world</h1>
+
+<%= link_to "Submit a new image", new_image_path %>

--- a/app/views/application/home.html.erb
+++ b/app/views/application/home.html.erb
@@ -1,3 +1,13 @@
 <h1>Hello world</h1>
 
 <%= link_to "Submit a new image", new_image_path %>
+
+<main>
+  <ul id="image-list">
+    <% @images.each do |image| %>
+      <li>
+        <%= image_tag image.url %>
+      </li>
+    <% end %>
+  </ul>
+</main>

--- a/app/views/application/home.html.erb
+++ b/app/views/application/home.html.erb
@@ -7,7 +7,7 @@
     <% @images.each do |image| %>
       <li>
         <a href="<%= image_path(image) %>">
-          <%= image_tag image.url %>
+          <%= image_tag image.url, class: 'image-thumbnail' %>
         </a>
       </li>
     <% end %>

--- a/app/views/application/home.html.erb
+++ b/app/views/application/home.html.erb
@@ -6,7 +6,9 @@
   <ul id="image-list">
     <% @images.each do |image| %>
       <li>
-        <%= image_tag image.url %>
+        <a href="<%= image_path(image) %>">
+          <%= image_tag image.url %>
+        </a>
       </li>
     <% end %>
   </ul>

--- a/app/views/images/new.html.erb
+++ b/app/views/images/new.html.erb
@@ -1,6 +1,19 @@
 <%= form_with scope: :image, url: images_path, local: true do |f| %>
   <h1>Submit an Image</h1>
 
+  <% if @image.errors.any? %>
+    <div id="error_explanation">
+      <h2>
+        <%= pluralize(@image.errors.count, 'issue') %> prevented your image from being saved:
+      </h2>
+      <ul>
+        <% @image.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
   <p>
     <%= f.label :url, 'Image URL' %><br>
     <%= f.text_field :url %>

--- a/app/views/images/new.html.erb
+++ b/app/views/images/new.html.erb
@@ -19,5 +19,10 @@
     <%= f.text_field :url %>
   </p>
 
+  <p>
+    <%= f.label :tag_list, 'Tags (one per line)' %><br>
+    <%= f.text_area :tag_list %>
+  </p>
+
   <%= f.submit %>
 <% end %>

--- a/app/views/images/new.html.erb
+++ b/app/views/images/new.html.erb
@@ -1,0 +1,10 @@
+<%= form_with scope: :image, url: images_path, local: true do |f| %>
+  <h1>Submit an Image</h1>
+
+  <p>
+    <%= f.label :url, 'Image URL' %><br>
+    <%= f.text_field :url %>
+  </p>
+
+  <%= f.submit %>
+<% end %>

--- a/app/views/images/show.html.erb
+++ b/app/views/images/show.html.erb
@@ -1,3 +1,14 @@
 <main>
   <%= image_tag @image.url %>
+
+  <h2>Tags</h2>
+  <% if @image.tag_list.present? %>
+    <ul id="tag-list">
+      <% @image.tag_list.each do |tag| %>
+        <li><%= tag %></li>
+      <% end %>
+    </ul>
+  <% else %>
+    <p>No tags</p>
+  <% end %>
 </main>

--- a/app/views/images/show.html.erb
+++ b/app/views/images/show.html.erb
@@ -1,0 +1,3 @@
+<main>
+  <%= image_tag @image.url %>
+</main>

--- a/config/initializers/acts_as_taggable_on.rb
+++ b/config/initializers/acts_as_taggable_on.rb
@@ -1,0 +1,2 @@
+ActsAsTaggableOn.delimiter = "\n"
+ActsAsTaggableOn.force_lowercase = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root 'application#home'
+
+  resources :images
 end

--- a/db/migrate/20200624223651_create_images.rb
+++ b/db/migrate/20200624223651_create_images.rb
@@ -1,0 +1,9 @@
+class CreateImages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :images do |t|
+      t.string :url
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200626201123_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200626201123_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,37 @@
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration[4.2]; end
+else
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration; end
+end
+ActsAsTaggableOnMigration.class_eval do
+  def self.up
+    create_table ActsAsTaggableOn.tags_table do |t|
+      t.string :name
+      t.timestamps
+    end
+
+    create_table ActsAsTaggableOn.taggings_table do |t|
+      t.references :tag, foreign_key: { to_table: ActsAsTaggableOn.tags_table }
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    drop_table ActsAsTaggableOn.taggings_table
+    drop_table ActsAsTaggableOn.tags_table
+  end
+end

--- a/db/migrate/20200626201124_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200626201124_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,26 @@
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingUniqueIndices < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingUniqueIndices < ActiveRecord::Migration; end
+end
+AddMissingUniqueIndices.class_eval do
+  def self.up
+    add_index ActsAsTaggableOn.tags_table, :name, unique: true
+
+    remove_index ActsAsTaggableOn.taggings_table, :tag_id if index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+    add_index ActsAsTaggableOn.taggings_table,
+              [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.tags_table, :name
+
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_idx'
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20200626201125_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200626201125_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,20 @@
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[4.2]; end
+else
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration; end
+end
+AddTaggingsCounterCacheToTags.class_eval do
+  def self.up
+    add_column ActsAsTaggableOn.tags_table, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, ActsAsTaggableOn.taggings_table)
+    end
+  end
+
+  def self.down
+    remove_column ActsAsTaggableOn.tags_table, :taggings_count
+  end
+end

--- a/db/migrate/20200626201126_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200626201126_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingTaggableIndex < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingTaggableIndex < ActiveRecord::Migration; end
+end
+AddMissingTaggableIndex.class_eval do
+  def self.up
+    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20200626201127_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200626201127_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ChangeCollationForTagNames < ActiveRecord::Migration[4.2]; end
+else
+  class ChangeCollationForTagNames < ActiveRecord::Migration; end
+end
+ChangeCollationForTagNames.class_eval do
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE #{ActsAsTaggableOn.tags_table} MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/migrate/20200626201128_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200626201128_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,23 @@
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration; end
+end
+AddMissingIndexesOnTaggings.class_eval do
+  def change
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists? ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_id unless index_exists? ActsAsTaggableOn.taggings_table, :taggable_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_type unless index_exists? ActsAsTaggableOn.taggings_table, :taggable_type
+    add_index ActsAsTaggableOn.taggings_table, :tagger_id unless index_exists? ActsAsTaggableOn.taggings_table, :tagger_id
+    add_index ActsAsTaggableOn.taggings_table, :context unless index_exists? ActsAsTaggableOn.taggings_table, :context
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, [:tagger_id, :tagger_type]
+      add_index ActsAsTaggableOn.taggings_table, [:tagger_id, :tagger_type]
+    end
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+      add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+    end
+  end
+end

--- a/db/migrate/20200626201253_add_image_tags.rb
+++ b/db/migrate/20200626201253_add_image_tags.rb
@@ -1,0 +1,5 @@
+class AddImageTags < ActiveRecord::Migration[5.2]
+  def change
+    add_column :images, :tags, :string, null: false, default: ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_26_201128) do
+ActiveRecord::Schema.define(version: 2020_06_26_201253) do
 
   create_table "images", force: :cascade do |t|
     t.string "url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "tags", default: "", null: false
   end
 
   create_table "taggings", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,39 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_24_223651) do
+ActiveRecord::Schema.define(version: 2020_06_26_201128) do
 
   create_table "images", force: :cascade do |t|
     t.string "url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "taggings", force: :cascade do |t|
+    t.integer "tag_id"
+    t.string "taggable_type"
+    t.integer "taggable_id"
+    t.string "tagger_type"
+    t.integer "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at"
+    t.index ["context"], name: "index_taggings_on_context"
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_id", "taggable_type", "context"], name: "taggings_taggable_context_idx"
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,6 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2020_06_24_223651) do
+
+  create_table "images", force: :cascade do |t|
+    t.string "url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,25 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+image_seeds = [
+  'https://images.dog.ceo/breeds/terrier-norfolk/n02094114_1330.jpg',
+  'https://images.dog.ceo/breeds/spaniel-blenheim/n02086646_127.jpg',
+  'https://images.dog.ceo/breeds/shiba/shiba-10.jpg',
+  'https://images.dog.ceo/breeds/dhole/n02115913_312.jpg',
+  'https://images.dog.ceo/breeds/chow/n02112137_7668.jpg',
+  'https://images.dog.ceo/breeds/chow/n02112137_16109.jpg',
+  'https://avatars.githubusercontent.com/u/15284810',
+  'https://images.dog.ceo/breeds/shiba/shiba-6.jpg',
+  'https://images.dog.ceo/breeds/mountain-bernese/n02107683_4386.jpg',
+  'https://images.dog.ceo/breeds/pug/n02110958_6966.jpg',
+  'https://images.dog.ceo/breeds/dhole/n02115913_139.jpg',
+  'https://images.dog.ceo/breeds/terrier-fox/n02095314_777.jpg',
+  'https://images.dog.ceo/breeds/hound-afghan/n02088094_13145.jpg',
+  'https://images.dog.ceo/breeds/hound-afghan/n02088094_13270.jpg',
+  'https://images.dog.ceo/breeds/greyhound-italian/n02091032_1743.jpg',
+  'https://images.dog.ceo/breeds/elkhound-norwegian/n02091467_6920.jpg',
+  'https://images.dog.ceo/breeds/deerhound-scottish/n02092002_4230.jpg',
+  'https://images.dog.ceo/breeds/boxer/n02108089_1560.jpg',
+  'https://images.dog.ceo/breeds/setter-irish/n02100877_8321.jpg'
+]
+
+image_seeds.each do |url|
+  Image.create!(url: url)
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,25 +1,25 @@
 image_seeds = [
-  'https://images.dog.ceo/breeds/terrier-norfolk/n02094114_1330.jpg',
-  'https://images.dog.ceo/breeds/spaniel-blenheim/n02086646_127.jpg',
-  'https://images.dog.ceo/breeds/shiba/shiba-10.jpg',
-  'https://images.dog.ceo/breeds/dhole/n02115913_312.jpg',
-  'https://images.dog.ceo/breeds/chow/n02112137_7668.jpg',
-  'https://images.dog.ceo/breeds/chow/n02112137_16109.jpg',
-  'https://avatars.githubusercontent.com/u/15284810',
-  'https://images.dog.ceo/breeds/shiba/shiba-6.jpg',
-  'https://images.dog.ceo/breeds/mountain-bernese/n02107683_4386.jpg',
-  'https://images.dog.ceo/breeds/pug/n02110958_6966.jpg',
-  'https://images.dog.ceo/breeds/dhole/n02115913_139.jpg',
-  'https://images.dog.ceo/breeds/terrier-fox/n02095314_777.jpg',
-  'https://images.dog.ceo/breeds/hound-afghan/n02088094_13145.jpg',
-  'https://images.dog.ceo/breeds/hound-afghan/n02088094_13270.jpg',
-  'https://images.dog.ceo/breeds/greyhound-italian/n02091032_1743.jpg',
-  'https://images.dog.ceo/breeds/elkhound-norwegian/n02091467_6920.jpg',
-  'https://images.dog.ceo/breeds/deerhound-scottish/n02092002_4230.jpg',
-  'https://images.dog.ceo/breeds/boxer/n02108089_1560.jpg',
-  'https://images.dog.ceo/breeds/setter-irish/n02100877_8321.jpg'
+  ['https://images.dog.ceo/breeds/terrier-norfolk/n02094114_1330.jpg', ['norfolk terrier']],
+  ['https://images.dog.ceo/breeds/spaniel-blenheim/n02086646_127.jpg', ['blenheim spaniel', 'humans???']],
+  ['https://images.dog.ceo/breeds/shiba/shiba-10.jpg', ['shiba inu']],
+  ['https://images.dog.ceo/breeds/dhole/n02115913_312.jpg', ['dhole']],
+  ['https://images.dog.ceo/breeds/chow/n02112137_7668.jpg', ['chow']],
+  ['https://images.dog.ceo/breeds/chow/n02112137_16109.jpg', ['chow']],
+  ['https://avatars.githubusercontent.com/u/15284810', ['chow', 'humans???']],
+  ['https://images.dog.ceo/breeds/shiba/shiba-6.jpg', ['shiba inu']],
+  ['https://images.dog.ceo/breeds/mountain-bernese/n02107683_4386.jpg', ['bernese mountain']],
+  ['https://images.dog.ceo/breeds/pug/n02110958_6966.jpg', ['pug']],
+  ['https://images.dog.ceo/breeds/dhole/n02115913_139.jpg', ['dhole']],
+  ['https://images.dog.ceo/breeds/terrier-fox/n02095314_777.jpg', ['fox terrier', 'humans???']],
+  ['https://images.dog.ceo/breeds/hound-afghan/n02088094_13145.jpg', ['afghan hound']],
+  ['https://images.dog.ceo/breeds/hound-afghan/n02088094_13270.jpg', ['afghan hound']],
+  ['https://images.dog.ceo/breeds/greyhound-italian/n02091032_1743.jpg', ['italian greyhound', 'humans???']],
+  ['https://images.dog.ceo/breeds/elkhound-norwegian/n02091467_6920.jpg', ['norwegian elkhound']],
+  ['https://images.dog.ceo/breeds/deerhound-scottish/n02092002_4230.jpg', ['scottish deerhound', 'humans???']],
+  ['https://images.dog.ceo/breeds/boxer/n02108089_1560.jpg', ['boxer']],
+  ['https://images.dog.ceo/breeds/setter-irish/n02100877_8321.jpg', ['irish setter', 'humans???']]
 ]
 
-image_seeds.each do |url|
-  Image.create!(url: url)
+image_seeds.each do |url, tag_list|
+  Image.create!(url: url, tag_list: tag_list)
 end

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class ApplicationControllerTest < ActionDispatch::IntegrationTest
+  test 'has a link to the image submission form' do
+    get root_url
+    assert_response :success
+    assert_select "a[href='#{new_image_path}']"
+  end
+end

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -6,4 +6,18 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select 'a[href=?]', new_image_path
   end
+
+  test 'displays newer images first' do
+    Image.delete_all
+    first_image = Image.create!(url: 'http://example.com/foo.png')
+    second_image = Image.create!(url: 'http://example.com/bar.png')
+
+    get root_url
+
+    assert_select 'img[src=?]', first_image.url
+    assert_select 'img[src=?]', second_image.url
+
+    assert body.index(second_image.url) < body.index(first_image.url),
+           'The most recent image should appear first'
+  end
 end

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -14,8 +14,12 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
 
     get root_url
 
-    assert_select 'img[src=?]', first_image.url
-    assert_select 'img[src=?]', second_image.url
+    assert_select 'a[href=?]', image_path(first_image) do
+      assert_select 'img[src=?]', first_image.url
+    end
+    assert_select 'a[href=?]', image_path(second_image) do
+      assert_select 'img[src=?]', second_image.url
+    end
 
     assert body.index(second_image.url) < body.index(first_image.url),
            'The most recent image should appear first'

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -4,6 +4,6 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
   test 'has a link to the image submission form' do
     get root_url
     assert_response :success
-    assert_select "a[href='#{new_image_path}']"
+    assert_select 'a[href=?]', new_image_path
   end
 end

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ImagesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -1,7 +1,26 @@
 require 'test_helper'
 
 class ImagesControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'does not show errors when first rendering the page' do
+    get new_image_url
+    assert_response :ok
+    assert_select '#error_explanation', count: 0
+  end
+
+  test 'adds valid images' do
+    image_src = 'http://example.com/foo.png'
+    assert_difference 'Image.count', 1 do
+      post images_url, params: { image: { url: image_src } }
+    end
+    assert_redirected_to Image.order(:created_at).last
+    follow_redirect!
+    assert_select "img[src='#{image_src}']"
+  end
+
+  test 'does not add invalid images' do
+    assert_no_changes 'Image.count' do
+      post images_path, params: { image: { url: '' } }
+    end
+    assert_select '#error_explanation'
+  end
 end

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -14,7 +14,7 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
     end
     assert_redirected_to Image.order(:created_at).last
     follow_redirect!
-    assert_select "img[src='#{image_src}']"
+    assert_select 'img[src=?]', image_src
   end
 
   test 'does not add invalid images' do

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -23,4 +23,18 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
     end
     assert_select '#error_explanation'
   end
+
+  test 'image information is shown' do
+    image_src = 'http://example.com/foo.png'
+    tag = 'bar'
+    image = Image.create!(url: image_src, tag_list: tag)
+
+    get image_url(image)
+    assert_response :ok
+
+    assert_select 'img[src=?]', image_src
+    assert_select '#tag-list' do
+      assert_select 'li', tag
+    end
+  end
 end

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -37,4 +37,22 @@ class ImageTest < ActiveSupport::TestCase
     refute @image.valid?
     assert_not_nil @image.errors[:url]
   end
+
+  test 'has no tags by default' do
+    assert_equal [], @image.tag_list
+  end
+
+  test 'newline delimited tags can be added' do
+    @image.tag_list = <<-TAGS
+      first tag
+      second tag
+    TAGS
+
+    assert_equal ['first tag', 'second tag'], @image.tag_list
+  end
+
+  test 'tags are normalized to lowercase' do
+    @image.tag_list = 'FOO'
+    assert_equal ['foo'], @image.tag_list
+  end
 end

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+class ImageTest < ActiveSupport::TestCase
+  def setup
+    @image = Image.new(url: 'http://example.com/foo.png')
+  end
+
+  test 'valid image' do
+    assert @image.valid?
+  end
+
+  test 'valid image with https link' do
+    @image.url = 'https://example.com/foo.png'
+    assert @image.valid?
+  end
+
+  test 'invalid when url is blank' do
+    @image.url = ''
+    refute @image.valid?
+    assert_not_nil @image.errors[:url]
+  end
+
+  test 'invalid when url is nil' do
+    @image.url = nil
+    refute @image.valid?
+    assert_not_nil @image.errors[:url]
+  end
+
+  test 'invalid when url is not a url' do
+    @image.url = '???'
+    refute @image.valid?
+    assert_not_nil @image.errors[:url]
+  end
+
+  test 'invalid when url protocol is not http or https' do
+    @image.url = 'ws://example.com/foo.png'
+    refute @image.valid?
+    assert_not_nil @image.errors[:url]
+  end
+end


### PR DESCRIPTION
Closes #6.

This PR allows tags to be attached to images during submission. A tags field is added to the submission form, allowing a newline delimited list of tags to be added. Additionally, a list of tags is displayed when viewing an individual image.

Draft until #13 is merged, can rebase after.